### PR TITLE
modify for building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The demos use GLUT and require GLUT to be installed.
 Obtaining OpenGL
 ----------------
 OpenGL is available on most UNIX(R) workstations,
-as well as OS/2(R) and Windows NT.  Contact your
+as well as OS/2(R) and Windows.  Contact your
 workstation vendor for more information; the URL
 http://www.opengl.org/ points to a variety of 
 information, including a list of OpenGL vendors. 
@@ -118,15 +118,17 @@ Python, SWIG
 Python bindings for gle can be found in the /swig directory.
 Be sure to read the readme.
 
-Compiling for Windows NT
+Compiling for Windows
 ------------------------
 To compile with Visual C++, just do the following:
 
+```
 cd src
-cl -c -DWIN32  *.c
-lib -out:libgle.lib *.obj
+cl -c -DWIN32 -DOPENGL_10=1 *.c
+lib -out:gle.lib *.obj
+```
 
-Alternately, there are a set of Microsoft Visual C Studio Project
+Alternately, there are a set of Microsoft Visual Studio Project
 files in the directory ms-visual-c that should do the same thing.
 
 

--- a/ms-visual-c/gle/gle.dsp
+++ b/ms-visual-c/gle/gle.dsp
@@ -43,8 +43,8 @@ RSC=rc.exe
 # PROP Target_Dir ""
 # ADD BASE F90 /compile_only /nologo /warn:nofileopt
 # ADD F90 /compile_only /nologo /warn:nofileopt
-# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
-# ADD CPP /nologo /MD /W3 /GX /O2 /I "." /D "WIN32" /D "NDEBUG" /D "_MBCS" /D "_LIB" /FD /c
+# ADD BASE CPP /nologo /W3 /GX /O2 /D "WIN32" /D "OPENGL_10=1" /D "NDEBUG" /D "_MBCS" /D "_LIB" /YX /FD /c
+# ADD CPP /nologo /MD /W3 /GX /O2 /I "." /I "../../src/GL" /D "WIN32" /D "OPENGL_10=1" /D "NDEBUG" /D "_MBCS" /D "_LIB" /FD /c
 # SUBTRACT CPP /YX
 # ADD BASE RSC /l 0x41d /d "NDEBUG"
 # ADD RSC /l 0x41d /d "NDEBUG"
@@ -56,7 +56,7 @@ LIB32=link.exe -lib
 # ADD LIB32 /nologo /out:"..\lib\gle.lib"
 # Begin Special Build Tool
 SOURCE="$(InputPath)"
-PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\gle.h ..\include\GL
+PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\GL\gle.h ..\include\GL
 # End Special Build Tool
 
 !ELSEIF  "$(CFG)" == "gle - Win32 Debug"
@@ -73,8 +73,8 @@ PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\gle.h ..\include\GL
 # PROP Target_Dir ""
 # ADD BASE F90 /check:bounds /compile_only /debug:full /nologo /traceback /warn:argument_checking /warn:nofileopt
 # ADD F90 /check:bounds /compile_only /debug:full /nologo /traceback /warn:argument_checking /warn:nofileopt
-# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
-# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "." /D "WIN32" /D "_DEBUG" /D "_MBCS" /D "_LIB" /FD /GZ /c
+# ADD BASE CPP /nologo /W3 /Gm /GX /ZI /Od /D "WIN32" /D "OPENGL_10=1" /D "_DEBUG" /D "_MBCS" /D "_LIB" /YX /FD /GZ /c
+# ADD CPP /nologo /MDd /W3 /Gm /GX /ZI /Od /I "." /I "../../src/GL" /D "WIN32" /D "OPENGL_10=1" /D "_DEBUG" /D "_MBCS" /D "_LIB" /FD /GZ /c
 # SUBTRACT CPP /YX
 # ADD BASE RSC /l 0x41d /d "_DEBUG"
 # ADD RSC /l 0x41d /d "_DEBUG"
@@ -86,7 +86,7 @@ LIB32=link.exe -lib
 # ADD LIB32 /nologo /out:"..\lib\gled.lib"
 # Begin Special Build Tool
 SOURCE="$(InputPath)"
-PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\gle.h ..\include\GL
+PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\GL\gle.h ..\include\GL
 # End Special Build Tool
 
 !ENDIF 
@@ -98,6 +98,10 @@ PostBuild_Cmds=md ..\include	md ..\include\GL	copy ..\..\src\gle.h ..\include\GL
 # Begin Group "Source Files"
 
 # PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=..\..\src\ex_alpha.c
+# End Source File
 # Begin Source File
 
 SOURCE=..\..\src\ex_angle.c
@@ -164,7 +168,7 @@ SOURCE=..\..\src\extrude.h
 # End Source File
 # Begin Source File
 
-SOURCE=..\..\src\gle.h
+SOURCE=..\..\src\GL\gle.h
 # End Source File
 # Begin Source File
 


### PR DESCRIPTION
- README.md: add compile option "-DOPENGL_10=1" and change the target name.
- ms-visual-c/gle/gle.dsp: add "ex_alpha.c" to source list,
  modify the path of gle.h, and add compile option "-DOPENGL_10=1"